### PR TITLE
Fix: When a model doesn't have default args we crash

### DIFF
--- a/flask_sillywalk.py
+++ b/flask_sillywalk.py
@@ -70,6 +70,7 @@ class SwaggerApiRegistry(object):
             "properties": dict()}
         argspec = inspect.getargspec(c.__init__)
         argspec.args.remove("self")
+        defaults = {}
         if argspec.defaults:
             defaults = zip(argspec.args[-len(
                 argspec.defaults):], argspec.defaults)


### PR DESCRIPTION
When a model doesn't have default args (kw args with a default value) we crash. This fixes that
