### PR TITLE
Fix error using blueprints

### DIFF
--- a/flask_sillywalk.py
+++ b/flask_sillywalk.py
@@ -37,6 +37,7 @@ class SwaggerApiRegistry(object):
         self.basepath = urlparse(self.baseurl).path
         self.r = defaultdict(dict)
         self.models = defaultdict(dict)
+        self.registered_routes = []
         if app is not None:
             self.app = app
             self.init_app(self.app)
@@ -172,13 +173,14 @@ class SwaggerApiRegistry(object):
 
             if api.resource not in self.app.view_functions:
                 for fmt in SUPPORTED_FORMATS:
-                    self.app.add_url_rule(
-                        "{0}/{1}.{2}".format(
-                        self.basepath.rstrip("/"),
-                        api.resource,
-                        fmt),
-                        api.resource,
-                        self.show_resource(api.resource))
+                    route = "{0}/{1}.{2}".format(self.basepath.rstrip("/"),
+                                                 api.resource, fmt)
+                    if route not in self.registered_routes:
+                        self.registered_routes.append(route)
+                        self.app.add_url_rule(
+                            route,
+                            api.resource,
+                            self.show_resource(api.resource))
 
             if self.r[api.resource].get(api.path) is None:
                 self.r[api.resource][api.path] = list()


### PR DESCRIPTION
Fixes an error which occurs when using Blueprints and multiple routes
with the same name but different parameters.

```
AssertionError: View function mapping is overwriting an existing
endpoint function: blueprint.hello
```

Below is an example code listing to demonstrate how to reproduce the
error.

web.py

```
from flask import Flask
from blueprint import blueprint

app = Flask(__name__)

app.register_blueprint(blueprint)

if __name__ == "__main__":
    app.run()
```

blueprint.py

```
from flask import Flask
from flask import Blueprint
from flask_sillywalk import SwaggerApiRegistry
from flask_sillywalk import ApiParameter
from flask_sillywalk import ApiErrorResponse

blueprint = Blueprint('blueprint', __name__,
                        template_folder='templates')

registry = SwaggerApiRegistry(
  blueprint,
  baseurl="http://localhost:5000",
  api_version="1.0",
  api_descriptions={})
register = registry.register
registerModel = registry.registerModel

@register("/hello/")
def hello_blank():
    return "Hello World!"

@register("/hello/<name>/")
def hello_name(name):
    return "Hello " + name + "!"
```

This fixes when using blueprints with no prefix, when using blueprints
with prefixes the URLs returned to not contain the prefix.
