### PR TITLE
Add nickname as parameter to register decorator

### DIFF
--- a/flask_sillywalk.py
+++ b/flask_sillywalk.py
@@ -130,6 +130,7 @@ class SwaggerApiRegistry(object):
             content_type="application/json",
             parameters=[],
             responseMessages=[],
+            nickname=None,
             notes=None):
         """
         Registers an API endpoint.
@@ -172,6 +173,7 @@ class SwaggerApiRegistry(object):
                 httpMethod=method,
                 params=parameters,
                 responseMessages=responseMessages,
+                nickname=nickname,
                 notes=notes)
 
             if api.resource not in self.app.view_functions:


### PR DESCRIPTION
Latest version of Swagger UI does not seem to accept empty nicknames in operations. I added a keyword argument 'nickname' to register function to be able to specify non null nicknames. 

With the example from the README, it would be used as follows:

``` python
@register("/api/v1/cheese/<cheeseName>",
  parameters=[
    ApiParameter(
        name="cheeseName",
        description="The name of the cheese to fetch",
        required=True,
        dataType="str",
        paramType="path",
        allowMultiple=False)
  ],
  nickname="cheeseNickName",
  responseMessages=[
    ApiErrorResponse(400, "Sorry, we're fresh out of that cheese.")
  ])
```

Related to #2.
