### PR TITLE
Swagger HTML doc rendering

### DIFF
--- a/example.py
+++ b/example.py
@@ -8,6 +8,12 @@ from flask_sillywalk import SwaggerApiRegistry, ApiParameter, ApiErrorResponse
 
 app = Flask("foobar")
 
+@app.template_filter()
+def is_list(value):
+    return isinstance(value, list)
+
+app.jinja_env.filters['is_list'] = is_list
+
 url = os.environ.get("URL", "localhost:5000")
 registry = SwaggerApiRegistry(app, baseurl="http://{}/api/v1".format(url))
 register = registry.register

--- a/example.py
+++ b/example.py
@@ -15,7 +15,7 @@ def is_list(value):
 app.jinja_env.filters['is_list'] = is_list
 
 url = os.environ.get("URL", "localhost:5000")
-registry = SwaggerApiRegistry(app, baseurl="http://{}/api/v1".format(url))
+registry = SwaggerApiRegistry(app, baseurl="http://localhost:5000/api/v1".format(url))
 register = registry.register
 registerModel = registry.registerModel
 

--- a/flask_sillywalk.py
+++ b/flask_sillywalk.py
@@ -1,6 +1,7 @@
 import inspect
 import json
 from collections import defaultdict
+import collections
 from urlparse import urlparse
 from flask import render_template
 from flask.views import View
@@ -214,24 +215,22 @@ class SwaggerApiRegistry(object):
                 nickname=nickname,
                 notes=notes)
 
-            if self.r[api.resource].get(api.path) is None:
-                self.r[api.resource][api.path] = list()
-            self.r[api.resource][api.path].append(api)
+            if self.r[api.ret["resource"]].get(api.ret["path"]) is None:
+                self.r[api.ret["resource"]][api.ret["path"]] = list()
+            self.r[api.ret["resource"]][api.ret["path"]].append(api)
 
-            if api.resource not in self.app.view_functions:
+            if api.ret["resource"] not in self.app.view_functions:
                 for fmt in SUPPORTED_FORMATS:
                     route = "{0}/{1}.{2}".format(self.basepath.rstrip("/"),
-                                                 api.resource, fmt)
+                                                 api.ret["resource"], fmt)
                     if route not in self.registered_routes:
                         self.registered_routes.append(route)
                         if fmt == "html":
-                             self.app.add_url_rule(route,
-                                view_func=RenderTemplateView.as_view('resource_'+api.resource+'_layout', template_name='resource_layout.html', json=self.resourcesSerializer(api.resource)()))
+                            self.app.add_url_rule(route,
+                                view_func=RenderTemplateView.as_view('resource_'+api.ret["resource"]+'_layout', template_name='resource_layout.html', json=self.resourcesSerializer(api.ret["resource"])(), hostname=self.hostname))
                         else:
-                            self.app.add_url_rule(
-                                route,
-                                api.resource,
-                                self.show_resource(api.resource))
+                            self.app.add_url_rule(route,
+                                'resource_'+api.ret["resource"]+'_json', self.jsonify(self.resourcesSerializer(api.ret["resource"])))
 
         return inner_func
 
@@ -264,11 +263,12 @@ class SwaggerApiRegistry(object):
 
 
 class RenderTemplateView(View):
-    def __init__(self, template_name, json):
+    def __init__(self, template_name, json, hostname=None):
         self.template_name = template_name
         self.json = json
+        self.hostname = hostname
     def dispatch_request(self):
-        return render_template(self.template_name, parameters=[self.json], apis=[self.json['apis']])
+        return render_template(self.template_name, parameters=[self.json], apis=[self.json["apis"]], hostname=self.hostname)
 
 
 class SwaggerDocumentable(object):
@@ -282,7 +282,7 @@ class SwaggerDocumentable(object):
 
 class Api(SwaggerDocumentable):
     """
-    A single API endpoint.
+    A single API endpoint
     """
 
     def __init__(
@@ -294,22 +294,22 @@ class Api(SwaggerDocumentable):
             responseMessages=None,
             nickname=None,
             notes=None):
-        self.httpMethod = httpMethod
-        self.summary = method.__doc__ if method.__doc__ is not None else ""
-        self.resource = path.lstrip("/").split("/")[0]
-        self.path = path.replace("<", "{").replace(">", "}")
-        self.parameters = [] if params is None else params
-        self.responseMessages = [] if responseMessages is None else responseMessages
-        self.nickname = "" if nickname is None else nickname
-        self.notes = notes
+        self.ret = odict.OrderedDict()
+        self.ret["httpMethod"] = httpMethod
+        self.ret["path"] = path.replace("<", "{").replace(">", "}")
+        self.ret["resource"] = path.lstrip("/").split("/")[0]
+        self.ret["parameters"] = [] if params is None else params
+        self.ret["responseMessages"] = [] if responseMessages is None else responseMessages
+        self.ret["nickname"] = "" if nickname is None else nickname
+        self.ret["notes"] = notes
+        self.ret["summary"] = method.__doc__ if method.__doc__ is not None else ""
 
     # See https://github.com/wordnik/swagger-core/wiki/API-Declaration
     def document(self):
-        ret = self.__dict__.copy()
         # need to serialize these guys
-        ret["parameters"] = [p.document() for p in self.parameters]
-        ret["responseMessages"] = [e.document() for e in self.responseMessages]
-        return ret
+        self.ret["parameters"] = [p.document() for p in self.ret["parameters"]]
+        self.ret["responseMessages"] = [e.document() for e in self.ret["responseMessages"]]
+        return self.ret
 
     def __hash__(self):
         return hash(self.path)
@@ -328,15 +328,16 @@ class ApiParameter(SwaggerDocumentable):
             dataType,
             paramType,
             allowMultiple=False):
-        self.name = name
-        self.description = description
-        self.required = required
-        self.dataType = dataType
-        self.paramType = paramType
-        self.allowMultiple = allowMultiple
+        self.ret = odict.OrderedDict()
+        self.ret["name"] = name
+        self.ret["dataType"] = dataType
+        self.ret["required"] = required
+        self.ret["paramType"] = paramType
+        self.ret["allowMultiple"] = allowMultiple
+        self.ret["description"] = description
 
     def document(self):
-        return self.__dict__
+        return self.ret
 
 
 class ImplicitApiParameter(ApiParameter):

--- a/flask_sillywalk.py
+++ b/flask_sillywalk.py
@@ -1,6 +1,5 @@
 import inspect
 import json
-from collections import defaultdict
 import collections
 from urlparse import urlparse
 from flask import render_template
@@ -37,8 +36,8 @@ class SwaggerApiRegistry(object):
         self.api_version = api_version
         self.api_descriptions = api_descriptions
         self.basepath = urlparse(self.baseurl).path
-        self.r = defaultdict(dict)
-        self.models = defaultdict(dict)
+        self.r = collections.defaultdict(dict)
+        self.models = collections.defaultdict(dict)
         self.registered_routes = []
         if app is not None:
             self.app = app

--- a/static/style.css
+++ b/static/style.css
@@ -1,0 +1,11 @@
+body {
+    font-family: 'Georgia', serif;
+    font-size: 16px;
+    margin: 30px;
+    padding: 0;
+}
+
+table {
+    border-spacing: 2em;
+    border-collapse: separate;
+}

--- a/static/style.css
+++ b/static/style.css
@@ -9,3 +9,12 @@ table {
     border-spacing: 2em;
     border-collapse: separate;
 }
+
+.path, .method {
+    float: left;
+    padding: 1em;
+}
+
+.params {
+    clear: both;
+}

--- a/static/style.css
+++ b/static/style.css
@@ -5,8 +5,12 @@ body {
     padding: 0;
 }
 
+.grid {
+    margin-left: -1em; /* remove outer border spacing */
+}
+
 table {
-    border-spacing: 2em;
+    border-spacing: 1em;
     border-collapse: separate;
 }
 

--- a/templates/docs_layout.html
+++ b/templates/docs_layout.html
@@ -1,0 +1,22 @@
+<!doctype html>
+<head>
+<title>API {{ parameters.0.apiVersion }} Docs</title>
+<link rel=stylesheet type=text/css href="{{ url_for('static', filename='style.css') }}">
+</head>
+<body>
+<h1>{% block title %}{% endblock %}</h1>
+{% for param in parameters %}
+    <table>
+        <tr>
+            <td>Api Version</td>
+            <td>Base Path</td>
+        </tr>
+        <tr>
+            <td>{{ param.apiVersion }}</td>
+            <td>{{ param.basePath }}</td>
+        <tr>
+    </table>
+{% endfor %}
+{% block body %}{% endblock %}
+</body>
+</html>

--- a/templates/resource_layout.html
+++ b/templates/resource_layout.html
@@ -8,18 +8,26 @@
     {% for key,value in a.items() %}
         {% if (loop.index == 1 or loop.index == 2) %}
             {% if loop.index == 1 %}
+                <h3><p>{{ value }}</p></h3>
+            {% endif %}
+            {% if loop.index == 2 %}
+                <p>{{ value }}</p>
+            {% endif %}
+        {% endif %}
+        {% if (loop.index == 3 or loop.index == 4) %}
+            {% if loop.index == 3 %}
                 <div class="method">
                     {{ value }}
                 </div>
             {% endif %}
-            {% if loop.index == 2 %}
+            {% if loop.index == 4 %}
                 <div class="path">
                     {{ parameters.0.basePath }}{{ value }}
                 </div>
             {% endif %}
         {% else %}
             {% if value | is_list %}
-                <div class="params">
+                <div class="params grid">
                     <table>
                     {% for i in value %}
                         {% if loop.index == 1 %}

--- a/templates/resource_layout.html
+++ b/templates/resource_layout.html
@@ -1,0 +1,41 @@
+<!doctype html>
+<head>
+<title>API {{ parameters.0.apiVersion }} Docs</title>
+<link rel=stylesheet type=text/css href="{{ url_for('static', filename='style.css') }}">
+</head>
+<body>
+{% for a in apis %}
+    <table>
+    {% for key,value in a.items() %}
+        {% if value %}
+        <tr>
+            <td>{{ key }}</td>
+            <td>
+            {% if value | is_list %}
+                {% for i in value %}
+                    <table>
+                    {% for ikey,ivalue in i.items() %}
+                            <thead>
+                                <tr>
+                                    <th>{{ ivalue }}</th>
+                                </tr>
+                            </thead>
+                            <tbody>
+                                <tr>
+                                    <td>{{ ikey }}</td>
+                                </tr>
+                            </tbody>
+                    {% endfor %}
+                    </table>
+                {% endfor %}
+            {% else %}
+                {{ value }}
+            {% endif %}
+            </td>
+        </tr>
+        {% endif %}
+    {% endfor %}
+    </table>
+{% endfor %}
+</body>
+</html>

--- a/templates/resource_layout.html
+++ b/templates/resource_layout.html
@@ -5,37 +5,45 @@
 </head>
 <body>
 {% for a in apis %}
-    <table>
     {% for key,value in a.items() %}
-        {% if value %}
-        <tr>
-            <td>{{ key }}</td>
-            <td>
+        {% if (loop.index == 1 or loop.index == 2) %}
+            {% if loop.index == 1 %}
+                <div class="method">
+                    {{ value }}
+                </div>
+            {% endif %}
+            {% if loop.index == 2 %}
+                <div class="path">
+                    {{ parameters.0.basePath }}{{ value }}
+                </div>
+            {% endif %}
+        {% else %}
             {% if value | is_list %}
-                {% for i in value %}
+                <div class="params">
                     <table>
-                    {% for ikey,ivalue in i.items() %}
+                    {% for i in value %}
+                        {% if loop.index == 1 %}
                             <thead>
-                                <tr>
-                                    <th>{{ ivalue }}</th>
+                                    <tr>
+                                    {% for ikey,ivalue in i.items() %}
+                                        <th>{{ ikey }}</th>
+                                    {% endfor %}
                                 </tr>
                             </thead>
+                        {% endif %}
                             <tbody>
                                 <tr>
-                                    <td>{{ ikey }}</td>
+                                    {% for ikey,ivalue in i.items() %}
+                                        <td>{{ ivalue }}</td>
+                                    {% endfor %}
                                 </tr>
                             </tbody>
                     {% endfor %}
                     </table>
-                {% endfor %}
-            {% else %}
-                {{ value }}
+                </div>
             {% endif %}
-            </td>
-        </tr>
         {% endif %}
     {% endfor %}
-    </table>
 {% endfor %}
 </body>
 </html>


### PR DESCRIPTION
Many times you want to render html documentation for your API. This allows you to using the data from the same decorators using to generate `swagger` json.

![screen shot 2015-02-20 at 9 40 44 am](https://cloud.githubusercontent.com/assets/410872/6288094/9fc34f1a-b8e4-11e4-99c6-19f54ebbda6b.png)

- HTML doc generation
- API and Resource Validators
- HTML jinja example templates